### PR TITLE
Feat new helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,14 +21,14 @@ yarn add h3-valibot
 ## Validation
 
 ```ts router.ts
-import { useValidatedBody, v } from 'h3-valibot'
+import { useValidatedBody, v, vh } from 'h3-valibot'
 
 import { createApp, createRouter, eventHandler } from 'h3';
 import { email, minLength, string, objectAsync } from 'valibot';
 
 export const app = createApp();
 const LoginSchema = v.object({
-    email: v.pipe(v.string(), v.email()),
+    email: vh.email,
     password: v.pipe(v.string(), v.minLength(8)),
  });
 

--- a/README.md
+++ b/README.md
@@ -78,8 +78,8 @@ It also provides a set of helpers via `vh` object, mainly related to string vali
 - `checkboxAsString`
 - `intAsString`
 - `numAsString`
-- `uuid`
 - `email`
+- `uuid`
 
 For more details or examples please refer to their JSdocs or [source code](/src/core/schemas.ts).
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ It also provides a set of helpers via `vh` object, mainly related to string vali
 
 - `boolAsString`
 - `checkboxAsString`
+- `dateAsString`
 - `intAsString`
 - `numAsString`
 - `email`

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ It also provides a set of helpers via `vh` object, mainly related to string vali
 - `intAsString`
 - `numAsString`
 - `uuid`
+- `email`
 
 For more details or examples please refer to their JSdocs or [source code](/src/core/schemas.ts).
 

--- a/src/core/schemas.ts
+++ b/src/core/schemas.ts
@@ -67,3 +67,14 @@ export const uuid = v.pipe(
   v.string(),
   v.uuid(e => `Must be a valid UUID, received: ${e.received}`),
 )
+
+/**
+ * Valibot schema to parse strings that are valid Email.
+ * @example
+ * ```ts
+ * v.parse(vh.email, 'user@example') -> throws an error
+ */
+export const email = v.pipe(
+  v.string(),
+  v.email(e => `Must be a valid Email, received: ${e.received}`),
+)

--- a/src/core/schemas.ts
+++ b/src/core/schemas.ts
@@ -58,6 +58,29 @@ export const numAsString = v.pipe(
 )
 
 /**
+ * Valibot schema to parse strings that are dates or datetime in ISO format.
+ * Use to parse <input type="date" /> and <input type="datetime-local" /> values.
+ * @example
+ * ```ts
+ * v.parse(dateAsString, '2022-01-01') -> new Date('2022-01-01')
+ * v.parse(datetimeAsString, '2022-01-01T12:00:00') -> new Date('2022-01-01T12:00:00')
+ * ```
+ */
+export const dateAsString = v.pipe(
+  v.union([
+    v.pipe(
+      v.string(),
+      v.isoDate(e => `Must be a date string in ISO format, received: ${e.received}`),
+    ),
+    v.pipe(
+      v.string(),
+      v.isoDateTime(e => `Must be a datetime string in ISO format, received: ${e.received}`),
+    ),
+  ]),
+  v.transform(d => new Date(d)),
+)
+
+/**
  * Valibot schema to parse strings that are valid UUID.
  * @example
  * ```ts

--- a/src/core/schemas.ts
+++ b/src/core/schemas.ts
@@ -63,7 +63,7 @@ export const numAsString = v.pipe(
  * @example
  * ```ts
  * v.parse(dateAsString, '2022-01-01') -> new Date('2022-01-01')
- * v.parse(datetimeAsString, '2022-01-01T12:00:00') -> new Date('2022-01-01T12:00:00')
+ * v.parse(dateAsString, '2022-01-01T12:00:00') -> new Date('2022-01-01T12:00:00')
  * ```
  */
 export const dateAsString = v.pipe(

--- a/test/schemas.test.ts
+++ b/test/schemas.test.ts
@@ -73,6 +73,18 @@ describe('numAsString', () => {
   })
 })
 
+describe('dateAsString', () => {
+  it('parses a valid date as string', () => {
+    expect(v.parse(vh.dateAsString, '1994-03-14')).toSatisfy(val => v.is(v.date(), val))
+  })
+  it('parses a valid datetime as string', () => {
+    expect(v.parse(vh.dateAsString, '1994-03-14T12:00')).toSatisfy(val => v.is(v.date(), val))
+  })
+  it('throws on non-date string', () => {
+    expect(() => v.parse(vh.dateAsString, '12:00')).toThrowError()
+  })
+})
+
 describe('uuid', () => {
   it('parses string to be a valid UUID', () => {
     expect(v.parse(vh.uuid, 'aa3452d1-ad94-4bd2-9782-1f69b3372784')).toBeTruthy()

--- a/test/schemas.test.ts
+++ b/test/schemas.test.ts
@@ -81,3 +81,12 @@ describe('uuid', () => {
     expect(() => v.parse(vh.uuid, '123')).toThrowError()
   })
 })
+
+describe('email', () => {
+  it('parses string to be a valid Email', () => {
+    expect(v.parse(vh.email, 'user@example.com')).toBeTruthy()
+  })
+  it('parses string to not be a valid Email', () => {
+    expect(() => v.parse(vh.email, 'user@example')).toThrowError()
+  })
+})


### PR DESCRIPTION
Introducing new helpers:
- `email`: much like `uuid`, it should be mainly used for prototyping
- `dateAsString`: as the other `*AsString` helpers, it takes a string and validate + transform it to a new `Date`